### PR TITLE
Fix: update() called before setup() on startup

### DIFF
--- a/L5.lua
+++ b/L5.lua
@@ -51,9 +51,9 @@ function love.run()
     -- Update dt
     if love.timer then dt = love.timer.step() end
     
-    -- Update
-    if love.update then love.update(dt) end
-    
+    -- Update per-frame framework state (mouse position, deltaTime, key, video looping)
+    L5_internal.updateFrameState(dt)
+
     -- Draw with double buffering
     if love.graphics and love.graphics.isActive() then
       love.graphics.origin()
@@ -75,6 +75,7 @@ function love.run()
         setup()
         setupComplete = true
       else
+        if update ~= nil then update() end
         if love.draw then love.draw() end
       end
       
@@ -164,7 +165,9 @@ function love.load()
   fill(255)
 end
 
-function love.update(dt)
+-- Per-frame framework bookkeeping (mouse position, deltaTime, key, video
+-- looping) - runs every frame regardless of whether setup() has completed
+function L5_internal.updateFrameState(dt)
   mouseX, mouseY = love.mouse.getPosition()
   movedX=mouseX-pmouseX
   movedY=mouseY-pmouseY
@@ -182,9 +185,6 @@ function love.update(dt)
       end
     end
   end
-
-  -- Optional update (not typically Processing-like but available)
-  if update ~= nil then update() end
 end
 
 function love.draw()
@@ -849,7 +849,7 @@ function L5_internal.defaults()
   TRIANGLE_STRIP = "strip"
 
   -- global user vars - can be read by user but shouldn't be altered by user
-  key = "" --default, overriden with key presses detected in love.update(dt)
+  key = "" --default, overriden with key presses detected in L5_internal.updateFrameState(dt)
   width = 800 --default, overridden with size() or fullscreen()
   height = 600 --ditto
   frameCount = 0


### PR DESCRIPTION
## Summary
Fixes #26

- `love.update(dt)` ran on startup and triggered user's `update()` before `setup()` had been run. This meant state initialised in `setup()` may not have been ready for update.

Lifecycle of applications should be:
```
setup()
update()
draw()
...
```

not

```
update()
setup()
draw()
update()
```


## Solution
- Split `love.update(dt)`'s per-frame framework bookkeeping (mouse position, `deltaTime`, `key`, video looping) into a new `L5_internal.updateFrameState(dt)`, which still runs unconditionally every frame - including the frame `setup()` runs on - so that state stays live during `setup()` exactly as before.
- The user's `update()` callback now lives in the same branch as `draw()`, which is only reached once `setup()` has completed - so `update()` naturally can't fire before `setup()`, with no flag needing to be shared across functions.

## Test plan
- [x] Reproduced the reported error (`attempt to perform arithmetic on global 'v' (a nil value)`) on pre-fix code using the issue's exact repro script run via `love`
- [x] Confirmed the same script runs cleanly post-fix, with `setup()` completing before `update()` fires
- [x] Confirmed `mouseX`, `mouseY`, `deltaTime`, and `key` are still live (non-default/non-nil) inside `setup()`
- [x] Ran the repo's `main.lua` example sketch to confirm no regression in normal draw-loop behavior
- [ ] Confirm change doesn't break other examples
