### PR TITLE
Remove update() from the L5 lifecycle

### DIFF
--- a/L5.lua
+++ b/L5.lua
@@ -51,9 +51,9 @@ function love.run()
     -- Update dt
     if love.timer then dt = love.timer.step() end
     
-    -- Update
-    if love.update then love.update(dt) end
-    
+    -- Refresh per-frame framework state (mouse position, deltaTime, key, video looping)
+    L5_internal.updateFrameState(dt)
+
     -- Draw with double buffering
     if love.graphics and love.graphics.isActive() then
       love.graphics.origin()
@@ -164,7 +164,10 @@ function love.load()
   fill(255)
 end
 
-function love.update(dt)
+-- Per-frame framework bookkeeping (mouse position, deltaTime, key, video
+-- looping). update() is not part of the L5 lifecycle - only setup() and
+-- draw() are - so this is purely internal plumbing, not a user callback.
+function L5_internal.updateFrameState(dt)
   mouseX, mouseY = love.mouse.getPosition()
   movedX=mouseX-pmouseX
   movedY=mouseY-pmouseY
@@ -182,9 +185,6 @@ function love.update(dt)
       end
     end
   end
-
-  -- Optional update (not typically Processing-like but available)
-  if update ~= nil then update() end
 end
 
 function love.draw()
@@ -849,7 +849,7 @@ function L5_internal.defaults()
   TRIANGLE_STRIP = "strip"
 
   -- global user vars - can be read by user but shouldn't be altered by user
-  key = "" --default, overriden with key presses detected in love.update(dt)
+  key = "" --default, overriden with key presses detected in L5_internal.updateFrameState(dt)
   width = 800 --default, overridden with size() or fullscreen()
   height = 600 --ditto
   frameCount = 0


### PR DESCRIPTION
## Summary
This is a follow-up to #26. That fix made `update()` fire strictly after `setup()`, but it's simpler to remove `update()` from the lifecycle entirely rather than keep juggling ordering around an optional, Processing-atypical callback.

L5's supported lifecycle is now just:
```
setup()
draw()
draw()
...
```
matching Processing/p5.js, rather than:
```
setup()
update()
draw()
update()
draw()
...
```

## Solution
- Removed the call to the user's `update()` callback and its `function love.update(dt)` wrapper entirely.
- The per-frame framework bookkeeping that used to live alongside it (mouse position, `deltaTime`, `key`, video looping) still needs to run every frame regardless of `update()`'s existence, so it's been extracted into `L5_internal.updateFrameState(dt)` - internal plumbing, not a user-facing callback - called unconditionally each frame from `love.run`'s main loop, in the same place `love.update(dt)` used to be called.
- No examples in this repo's `examples/` directory currently define/reference `update()`, so this is a clean removal as far as the codebase is concerned.

## Caveat: conflicts with the planned `noWindow()` / headless-mode design
Checked the docs site source (l5lua.org, `L5-website-gh-pages`) for any documented reliance on `update()`. `reference/noCanvas/index.html` documents `update()` as the *required* mechanism for headless sketches:

> "No code in `draw` can continue to run without a window. To have code continue to execute, you must add an `update()` function and place your code there."

with a sample sketch calling `noWindow()` then defining `update()` to keep executing.

However, `noWindow()`/`noCanvas()` aren't implemented in `L5.lua` at all currently (confirmed via grep) - it's still an open item in `docs/TODO.md` (`[ ] add noWindow() for headless mode`). So that documented example doesn't run today regardless of this change.

That said, this PR removes the only mechanism the docs currently prescribe for keeping a sketch running once `noWindow()` ships. Whoever implements headless mode will need to either reintroduce some form of `update()` scoped to that case, or design/document a different way to keep code executing without a window. Flagging so it isn't silently lost - not blocking this PR, but should be considered before/alongside implementing `noWindow()`.

## Test plan
- [x] Confirmed a sketch defining `update()` no longer has it called at all (state set in `update()` never takes effect)
- [x] Confirmed `mouseX`, `mouseY`, `deltaTime`, and `key` still update correctly every frame via `L5_internal.updateFrameState`
- [x] Ran the repo's `main.lua` example sketch to confirm no regression in normal draw-loop behavior
- [x] Checked docs site source for other documented reliance on `update()` - only the (currently non-functional) `noCanvas()` example, noted above
- [ ] Confirm change doesn't break other examples
